### PR TITLE
Added prints for shader compiler errors

### DIFF
--- a/header/Shader.h
+++ b/header/Shader.h
@@ -1,0 +1,16 @@
+#include <d3d12.h>
+#include <d3dcompiler.h>
+#include <wrl.h>
+#include <iostream>
+
+// Enum for shader type
+enum class ShaderType {
+	Vertex,
+	Pixel,
+	Geometry
+};
+
+bool CompileShader(const std::wstring& shaderFilePath, 
+	ShaderType shaderType,
+	ID3DBlob** shaderBlob,
+	ID3DBlob** errorBlob);

--- a/shader/PixelShader.hlsl
+++ b/shader/PixelShader.hlsl
@@ -24,6 +24,6 @@ float4 main(VS_OUTPUT input) : SV_TARGET
     float4 sh_color = {abs(sh), abs(sh1_1), abs(sh2_0), 1.0};
     //float4 sh_color = {0.0, abs(sh1_1), 0.0, 1.0};
     // return interpolated color
-     return input.color;
+    return input.color;
     //return sh_color;
 }

--- a/src/DxException.cpp
+++ b/src/DxException.cpp
@@ -8,8 +8,6 @@ std::wstring AnsiToWString(const std::string& str) {
     return wstrTo;
 }
 
-
-
 DxException::DxException(HRESULT hr, const std::wstring& functionName, const std::wstring& filename, int lineNumber)
     : ErrorCode(hr), FunctionName(functionName), Filename(filename), LineNumber(lineNumber) {}
 
@@ -19,5 +17,3 @@ const char* DxException::what() const noexcept {
         " at line " + std::to_string(LineNumber);
     return whatBuffer.c_str();
 }
-
-

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -1,0 +1,56 @@
+#include "Shader.h"
+
+bool CompileShader(const std::wstring& shaderFilePath, 
+    ShaderType shaderType,
+    ID3DBlob** shaderBlob, 
+    ID3DBlob** errorBlob)
+{
+  // Determine the target shader model on the shader type
+  const char* target = nullptr;
+  switch (shaderType)
+  {
+    case ShaderType::Vertex:
+      target = "vs_5_0";
+      break;
+    case ShaderType::Pixel:
+      target = "ps_5_0";
+      break;
+    case ShaderType::Geometry:
+      target = "gs_5_0";
+      break;
+    default:
+      std::cerr << "Unknown shader type." << std::endl;
+      return false;
+  }
+
+  HRESULT hr =
+      D3DCompileFromFile(shaderFilePath.c_str(), // Path to shader file
+                         nullptr,                // Optional macros
+                         nullptr,                // Optional include handler
+                         "main", 
+                         target, 
+                         D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 
+                         0, 
+                         shaderBlob, 
+                         errorBlob
+      );
+
+  if (FAILED(hr))
+  {
+    if (*errorBlob) {
+      //std::cerr << "Shader compilation failed:\n" << (char*)(*errorBlob)->GetBufferPointer() << std::endl;
+      std::cerr << "Shader compilation failed:\n"
+                << static_cast<const char*>((*errorBlob)->GetBufferPointer()) << std::endl;
+    }
+    else
+    {
+      std::cerr << "Shader compilation failed with HRESULT: " << std::hex << hr << std::endl;
+    }
+    return false;
+  }
+  else
+  {
+    std::cout << "Shader compiled successfully." << std::endl;
+    return true;
+  }
+}

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -11,6 +11,7 @@
 #include "d3dx12.h"
 #include <DxException.h>
 #include <GaussianRenderer.h>
+#include <Shader.h>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -230,29 +231,14 @@ bool Window::InitD3D()
 
   // create vertex and pixel shaders
   // compile vertex shader
-  ID3DBlob* vertexShader; // d3d blob for holding vertex shader bytecode
-  ID3DBlob* errorBuff;    // a buffer holding the error data if any
-  hr = D3DCompileFromFile(L"../shader/VertexShader.hlsl", nullptr, nullptr, "main", "vs_5_0",
-                          D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexShader, &errorBuff);
-
-  if (FAILED(hr))
-  {
-    if (errorBuff)
-    {
-      std::cerr << "Shader compilation failed:\n" << (char*)errorBuff->GetBufferPointer() << std::endl;
-      return false;
-    }
-    else
-    {
-      std::cerr << "Shader compilation failed with HRESULT: " << hr << std::endl;
-      return false;
-    }
-  }
-  else
-  {
-    std::cout << "Shader compiled successfully." << std::endl;
-  }
-
+   ID3DBlob* vertexShader = nullptr; // d3d blob for holding vertex shader bytecode
+   ID3DBlob* errorBuff = nullptr;    // a buffer holding the error data if any
+   std::wcout << L"Compiling vertex shader...\n";
+   if (!CompileShader(L"../shader/VertexShader.hlsl", ShaderType::Vertex, &vertexShader, &errorBuff))
+   {
+     std::cerr << "Failed to compile vertex shader." << std::endl;
+   }
+    
   // fill out a shader bytecode structure (which is basically just a pointer to the shader bytecode and the size of the
   // shader bytecode)
   D3D12_SHADER_BYTECODE vertexShaderBytecode = {};
@@ -260,9 +246,12 @@ bool Window::InitD3D()
   vertexShaderBytecode.pShaderBytecode       = vertexShader->GetBufferPointer();
 
   // compile pixel shader
-  ID3DBlob* pixelShader;
-  ThrowIfFailed(D3DCompileFromFile(L"../shader/PixelShader.hlsl", nullptr, nullptr, "main", "ps_5_0",
-                                   D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelShader, &errorBuff));
+  ID3DBlob* pixelShader = nullptr;
+  std::wcout << L"Compiling pixel shader...\n";
+  if (!CompileShader(L"../shader/PixelShader.hlsl", ShaderType::Pixel, &pixelShader, &errorBuff))
+  {
+    std::cerr << "Failed to compile pixel shader." << std::endl;
+  }
 
   // fill out shader bytecode structure for pixel shader
   D3D12_SHADER_BYTECODE pixelShaderBytecode = {};
@@ -270,13 +259,11 @@ bool Window::InitD3D()
   pixelShaderBytecode.pShaderBytecode       = pixelShader->GetBufferPointer();
 
   // compile geometry shader
-  ID3DBlob* geometryShader;
-  hr = D3DCompileFromFile(L"../shader/GeometryShader.hlsl", nullptr, nullptr, "main", "gs_5_0",
-                          D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &geometryShader, &errorBuff);
-  if (FAILED(hr))
+  ID3DBlob* geometryShader = nullptr;
+  std::wcout << L"Compiling geometry shader...\n";
+  if (!CompileShader(L"../shader/GeometryShader.hlsl", ShaderType::Geometry, &geometryShader, &errorBuff))
   {
-    OutputDebugStringA((char*)errorBuff->GetBufferPointer());
-    return false;
+    std::cerr << "Failed to compile geometry shader." << std::endl;
   }
 
   // fill out shader bytecode structure for geometry shader

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -234,10 +234,23 @@ bool Window::InitD3D()
   ID3DBlob* errorBuff;    // a buffer holding the error data if any
   hr = D3DCompileFromFile(L"../shader/VertexShader.hlsl", nullptr, nullptr, "main", "vs_5_0",
                           D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexShader, &errorBuff);
+
   if (FAILED(hr))
   {
-    OutputDebugStringA((char*)errorBuff->GetBufferPointer());
-    return false;
+    if (errorBuff)
+    {
+      std::cerr << "Shader compilation failed:\n" << (char*)errorBuff->GetBufferPointer() << std::endl;
+      return false;
+    }
+    else
+    {
+      std::cerr << "Shader compilation failed with HRESULT: " << hr << std::endl;
+      return false;
+    }
+  }
+  else
+  {
+    std::cout << "Shader compiled successfully." << std::endl;
   }
 
   // fill out a shader bytecode structure (which is basically just a pointer to the shader bytecode and the size of the


### PR DESCRIPTION
Shader compilation errors will be printed into the console if found.

Shader compilation was relocated into Shader.cpp to make the code reusable and clearer.